### PR TITLE
Support Graal Version 21.1.0

### DIFF
--- a/settings.sh
+++ b/settings.sh
@@ -1,6 +1,6 @@
 #!bash
 
 export IMAGE_NAME=findepi/graalvm # by necessity, this is also set in derived images' FROM directive
-export GRAAL_VERSION="21.0.0.2"
+export GRAAL_VERSION="21.1.0"
 export JDK_VERSION="${JDK_VERSION-java8}"
 export DEFAULT="${DEFAULT-false}"


### PR DESCRIPTION
GraalVM version 21.1.0 is out, opening this PR to propose a build of these docker images on this version.