### PR TITLE
Drop Java 8 and add Java 16-based builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        jdk_version: [ java8 ]
+        jdk_version: [ java11 ]
         default_image: [ true ]
         include:
-          - jdk_version: java11
+          - jdk_version: java16
             default_image: false
     timeout-minutes: 45
     steps:


### PR DESCRIPTION
Deprecation notice:
https://oss.oracle.com/pipermail/graalvm-announce/2021-September/000048.html