### PR TITLE
Upgrade to 21.3.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
         jdk_version: [ java11 ]
         default_image: [ true ]
         include:
-          - jdk_version: java16
+          - jdk_version: java17
             default_image: false
     timeout-minutes: 45
     steps:

--- a/settings.sh
+++ b/settings.sh
@@ -1,6 +1,6 @@
 #!bash
 
 export IMAGE_NAME=findepi/graalvm # by necessity, this is also set in derived images' FROM directive
-export GRAAL_VERSION="21.2.0"
+export GRAAL_VERSION="21.3.0"
 export JDK_VERSION="${JDK_VERSION-java11}"
 export DEFAULT="${DEFAULT-false}"


### PR DESCRIPTION
Java 16-based build is no longer available, replaced with 17-based.

Fixes https://github.com/findepi/graalvm-docker/issues/11 cc @premkumarramasamy 